### PR TITLE
Fix resizing problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,10 @@
     <body>
       <canvas id="canvas" width="400" height="400"></canvas>
       <div id="slider-container">
-        <label for="sides">Number of Sides: <span id="sides-value" style="font-size: 60px;">3</span>
+        <label for="sides">Number of Sides: <span id="sides-value" style="font-size: 60px;"></span>
         </label>
+      </div>
+      <div>
         <input type="range" id="sides" min="3" max="30" value="3">
       </div>
       <script>
@@ -65,11 +67,13 @@
 
         sidesInput.addEventListener('input', function() {
           const sides = parseInt(sidesInput.value);
-          sidesValue.textContent = sides;
+          sidesValue.textContent = sides.toString().padStart(2,0);
           drawPolygon(sides);
         });
-        
+
         // Initial drawing
+        const sides = parseInt(sidesInput.value);
+        sidesValue.textContent = sides.toString().padStart(2,0);
         drawPolygon(parseInt(sidesInput.value));
       </script>
     </body>


### PR DESCRIPTION
Pad number with zero. Spaces don't seem to work in padStart() function. May be an HTML thing that collapses spaces. 

Move slider to separate div so font sizes of changing numbers don't affect mouse and slider interaction.

Remove "3" from label and let initial code read from the sides range in case range start is changed in future.